### PR TITLE
Fix: SIK-1162 External Allow list doesn't work for docker scan

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -44,7 +44,7 @@ jobs:
             name: ${{ env.GHA_SECURITY_DOCKER_SCAN_IMAGE_ARTIFACT }}
         - name: "Check if allowlist file exists"
           env:
-            GHA_SECURITY_CODE_SCAN_EXTERNAL_REPOSITORY_TOKEN: ${{ secrets.external_repository_token }}
+            GHA_SECURITY_DOCKER_SCAN_EXTERNAL_REPOSITORY_TOKEN: ${{ secrets.external_repository_token }}
           run: |
             python -c "
             import os


### PR DESCRIPTION
Docker Scan script to retrieve external allow lists didn't have environment variable set