### PR TITLE
fix: update grype from commit to v6 major release

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -225,7 +225,7 @@ jobs:
 
       - name: "Anchore Grype Scan"
         id: anchore-scan
-        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a
+        uses: anchore/scan-action@v6
         with: 
           image: ${{ inputs.image_artifact }}.tar
           by-cve: true


### PR DESCRIPTION
 anchore/scan-action version is set to commithash for release [v3.6.4](https://github.com/anchore/scan-action/releases/tag/v3.6.4). 
 
Looked through releases to see for any major breaking changes that could affect our docker-scan script and I believe I found nothing that could impact us with how we use it. [V6.0.0](https://github.com/anchore/scan-action/releases/tag/v6.0.0) was released 3 weeks ago.