### PR TITLE
fix: add back download image artifact for docker-scan

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -32,6 +32,11 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@v4
 
+      - name: "Download the image artifact"
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.GHA_SECURITY_DOCKER_SCAN_IMAGE_ARTIFACT }}
+
       - name: Scanner Action
         uses: entur/gha-security/scanner-action@v2
         with:


### PR DESCRIPTION
Removed in #87 by accident.

Changes by #87 are not released yet, so bug isn't released.