### PR TITLE
feat: add upload-snapshot job and reduce permissions for docker-scan

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -31,7 +31,7 @@ jobs:
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.actor != 'dependabot[bot]') }}
     runs-on: ubuntu-24.04
     permissions:
-      contents: write # required for checking out the repository and creating files
+      contents: read # required for checking out the repository
       issues: write # required for creating issues, and/or adding issue comments
       pull-requests: write # required for creating comments on pull requests
       security-events: write # required for uploading SARIF file to GitHub 
@@ -81,7 +81,7 @@ jobs:
           fi
       - name: "Anchore Syft Scan"
         id: syft-scan
-        uses: anchore/sbom-action@17ae1740179002c89186b61233e0f892c3118b11 # v0
+        uses: LillieEntur/sbom-action@f6d2f16f68e4c4f81166614851f62874a052c6e0 # v0
         env:
           SYFT_EXCLUDE: ${{ env.DOCKER_WORKDIR }}
         with:
@@ -89,8 +89,15 @@ jobs:
           image: ${{ inputs.image_artifact }}.tar
           output-file: ${{ inputs.image_artifact }}.spdx.json
           artifact-name: ${{ inputs.image_artifact }}.spdx.json
-          dependency-snapshot: ${{ github.ref_name == github.event.repository.default_branch }}
+          dependency-snapshot-output-file: dependency-snapshot.github.sbom.json
+          github_token: ${{ secrets.GITHUB_TOKEN }}
         
+      - name: "Upload dependency snapshot"
+        uses: actions/upload-artifact@v7
+        with:
+          path: dependency-snapshot.github.sbom.json
+          archive: false
+
       - name: "Anchore Grype Scan"
         id: anchore-scan
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7
@@ -104,6 +111,7 @@ jobs:
         id: upload-vulnerability-report
         uses: github/codeql-action/upload-sarif@v4
         with: 
+          token: ${{ secrets.GITHUB_TOKEN }}
           sarif_file: ${{ steps.anchore-scan.outputs.sarif }}
           category: 'anchore-grype-scan'
       
@@ -142,3 +150,19 @@ jobs:
           channel-id: ${{ steps.scanner-action.outputs.notification_slack_channel_id }}
           payload: |
             ${{ env.NOTIFICATION_SLACK_POST_BLOCKS }}
+  upload-snapshot:
+    if: ${{ github.ref_name == github.event.repository.default_branch }}
+    runs-on: ubuntu-24.04
+    needs: [docker-scan]
+    permissions:
+      contents: write # required for uploading dependency snapshot file to GitHub
+    steps:
+      - name: "Download dependency snapshot"
+        uses: actions/download-artifact@v8
+        with:
+          name: dependency-snapshot.github.sbom.json
+      - name: "Upload dependency snapshot"
+        uses: LillieEntur/sbom-action/upload-github-snapshot@f6d2f16f68e4c4f81166614851f62874a052c6e0
+        with:
+          dependency-snapshot-input-file: dependency-snapshot.github.sbom.json
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 💡 What does this PR do?
<!--- Provide a concise summary of all the changes included in the pull request -->
Adds new job that has`contents: write` permissions set, and reduce permissions for **docker-scan** job to `contents: read`

> [!NOTE]  
> Waiting for pull request https://github.com/anchore/sbom-action/pull/616 to be approved and merged, temporary using my fork to allow for review of this pull request.


<!--- Provide a link to the Github/Jira ticket related to the pull request -->
Closes: [SIK-1887](https://entur.atlassian.net/browse/SIK-1887)

## 🔧 List of changes
<!--- Provide a list of each change included in the pull request -->
* Update steps to include token, instead of relying on default token value.
* Add upload-snapshot job
* Update docker-scan job to use `contents: write`

## 📋 Checklist
<!--- Follow up on, and tick off the tasks relevant to the pull request. Remove any irrelevant checks -->
- [x] Am familiar with the release pipeline for this project
- [x] I have verified that the project runs as expected after the new changes

[SIK-1887]: https://entur.atlassian.net/browse/SIK-1887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ