### PR TITLE
fix: reduce scope where github token is exposed under env

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -264,16 +264,6 @@ jobs:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}
           server-id: ${{ inputs.java_server_id_artifactory }}
-
-      - name: "Expose github token and github actor"
-        if: inputs.expose_github_token_and_actor
-        id: expose-github-token-actor
-        env:
-          GITHUB_ACTOR: ${{github.actor}}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "GITHUB_TOKEN=$GITHUB_TOKEN" >> "$GITHUB_ENV"
-          echo "GITHUB_ACTOR=$GITHUB_ACTOR" >> "$GITHUB_ENV"
         
       - name: "Gradle Dependency Graph for Scala"
         if: needs.get-repository-metadata.outputs.found_gradle == 'True' && (matrix.language == 'scala')
@@ -284,6 +274,7 @@ jobs:
           ARTIFACTORY_AUTH_USER: ${{ secrets.ARTIFACTORY_AUTH_USER }}
           ARTIFACTORY_AUTH_TOKEN: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
           ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+          GITHUB_TOKEN: ${{ inputs.expose_github_token_and_actor && github.token || '' }}
         with:
           cache-disabled: true
           add-job-summary: 'on-failure'
@@ -401,15 +392,6 @@ jobs:
               - exclude:
                   id: actions/missing-workflow-permissions
           token: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: "Expose github token and github actor"
-        if: inputs.expose_github_token_and_actor
-        env:
-          GITHUB_ACTOR: ${{github.actor}}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "GITHUB_TOKEN=$GITHUB_TOKEN" >> "$GITHUB_ENV"
-          echo "GITHUB_ACTOR=$GITHUB_ACTOR" >> "$GITHUB_ENV"
 
       - name: "Perform CodeQL Analysis"
         id: codeql-analysis
@@ -424,6 +406,7 @@ jobs:
           ARTIFACTORY_AUTH_TOKEN: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
           ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
           GRADLE_OPTS: ${{ inputs.gradle_opts }}
+          GITHUB_TOKEN: ${{ inputs.expose_github_token_and_actor && github.token || '' }}
           IS_CODEQL_SCAN: true
 
       - name: "Post message to job summary if scan with HTML only files fail"


### PR DESCRIPTION
## 💡 What does this PR do?
<!--- Provide a concise summary of all the changes included in the pull request -->
This pull request aims to reduce the scope of where Github token is exposed. Instead of setting it to global job env, instead do a conditional check.

Closes: [SIK-2009](https://entur.atlassian.net/browse/SIK-2009)

## 🔧 List of changes
<!--- Provide a list of each change included in the pull request -->
* code-scan.yml
   * remove "Expose github token and github actor" step for CodeQL and Semgrep
   * Add GITHUB_TOKEN env input with conditional check for setting value based on input.

## 📋 Checklist
<!--- Follow up on, and tick off the tasks relevant to the pull request. Remove any irrelevant checks -->
- [X] Am familiar with the release pipeline for this project
- [x] I have verified that the project runs as expected after the new changes

[SIK-2009]: https://entur.atlassian.net/browse/SIK-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ