### PR TITLE
fix: truncate allowlist comment if longer than 280 characters.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             - name: Setup Biome
               uses: biomejs/setup-biome@v2
               with:
-                version: 1.9.4
+                version: 2.4.16
                 working-dir: ./scanner-action
             - name: Run Biome
               working-directory: ./scanner-action

--- a/README-code-scan.md
+++ b/README-code-scan.md
@@ -219,7 +219,7 @@ The OPTIONAL `inherit` field MUST be the name of containing repository where con
 
 The OPTIONAL `allowlist` field MUST be a list of vulnerabilities that you want to dismiss/allow. For each vulnerability you want to dismiss, you MUST add a new item to the list. Each item is an object and MUST contain the following fields: `cwe`, `comment`, and `reason`.
 - The `cwe` field corresponds to the CWE-ID of the vulnerability you want to dismiss,
-- The `comment` field is a comment explaining why the vulnerability is dismissed.
+- The `comment` field is a comment explaining why the vulnerability is dismissed. Comments longer than 280 characters will be truncated.
 - The `reason` field MUST be one of the following types:
    - `false_positive` This alert is not valid
    - `wont_fix` This alert is not relevant

--- a/README-docker-scan.md
+++ b/README-docker-scan.md
@@ -212,7 +212,7 @@ The OPTIONAL `inherit` field MUST be the name of containing repository where con
 
 The OPTIONAL `allowlist` field MUST be a list of vulnerabilities that you want to dismiss/allow. For each vulnerability you want to dismiss, you MUST add a new item to the list. Each item is an object and MUST contain the following fields: `cwe`, `comment`, and `reason`.
 - The `cve` field corresponds to the CWE-ID of the vulnerability you want to dismiss,
-- The `comment` field is a comment explaining why the vulnerability is dismissed.
+- The `comment` field is a comment explaining why the vulnerability is dismissed. Comments longer than 280 characters will be truncated.
 - The `reason` field MUST be one of the following types:
    - `false_positive` This alert is not valid
    - `wont_fix` This alert is not relevant

--- a/scanner-action/allowlist.ts
+++ b/scanner-action/allowlist.ts
@@ -28,4 +28,4 @@ const runAllowlist = async (octokit: Octokit, tool: string, scannerConfig: Scann
 	await dismissAlerts(alerts, octokit, scannerConfig.spec?.allowlist ?? [], repository);
 };
 
-export { runAllowlist, type Allowlist };
+export { type Allowlist, runAllowlist };

--- a/scanner-action/biome.json
+++ b/scanner-action/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -7,15 +7,19 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["dist/index.cjs", "dist/package.json"]
+		"includes": ["*.ts"]
 	},
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab",
 		"lineWidth": 180
 	},
-	"organizeImports": {
-		"enabled": true
+	"assist": {
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
 	},
 	"linter": {
 		"enabled": true,

--- a/scanner-action/config.ts
+++ b/scanner-action/config.ts
@@ -3,7 +3,7 @@ import type { ThrottlingOptions } from "@octokit/plugin-throttling";
 
 const getOctokitThrottleConfig = () => {
 	const throttle: ThrottlingOptions = {
-		onRateLimit: (retryAfter, options, octokit, retryCount) => {
+		onRateLimit: (retryAfter, options, _octokit, retryCount) => {
 			core.warning(`Request quota exhausted for request ${options.method} ${options.url}`);
 
 			if (retryCount < 1) {
@@ -12,7 +12,7 @@ const getOctokitThrottleConfig = () => {
 				return true;
 			}
 		},
-		onSecondaryRateLimit: (retryAfter, options, octokit, retryCount) => {
+		onSecondaryRateLimit: (_retryAfter, options, _octokit, _retryCount) => {
 			// does not retry, only logs a warning
 			core.warning(`SecondaryRateLimit detected for request ${options.method} ${options.url}`);
 		},

--- a/scanner-action/dist/index.cjs
+++ b/scanner-action/dist/index.cjs
@@ -42000,6 +42000,7 @@ var dismissAlerts = async (alerts, octokit, allowlistEntries, repository) => {
       if (allowlistEntry.cwe) {
         return alert?.rule?.tags?.includes(`external/cwe/${allowlistEntry.cwe}`) && !dismissedAlerts.has(alert.number);
       }
+      return false;
     });
     for (const matchingAlert of matchingAlerts) {
       await octokit.rest.codeScanning.updateAlert({
@@ -42032,14 +42033,14 @@ var runAllowlist = async (octokit, tool, scannerConfig) => {
 // config.ts
 var getOctokitThrottleConfig = () => {
   const throttle = {
-    onRateLimit: (retryAfter, options, octokit, retryCount) => {
+    onRateLimit: (retryAfter, options, _octokit, retryCount) => {
       warning(`Request quota exhausted for request ${options.method} ${options.url}`);
       if (retryCount < 1) {
         info(`Retrying after ${retryAfter} seconds!`);
         return true;
       }
     },
-    onSecondaryRateLimit: (retryAfter, options, octokit, retryCount) => {
+    onSecondaryRateLimit: (_retryAfter, options, _octokit, _retryCount) => {
       warning(`SecondaryRateLimit detected for request ${options.method} ${options.url}`);
     }
   };
@@ -42098,7 +42099,7 @@ var removeIssueComment = async (issue2, subtext, octokit) => {
         ...issue2,
         comment_id: comment.id
       });
-    } catch (error2) {
+    } catch (_error) {
       warning(`Failed to remove comment ${comment.id} for issue: ${issue2.issue_number} with subtext ${subtext}`);
     }
   }
@@ -42431,13 +42432,13 @@ var validateAllowlist = (allowList) => {
   const GITHUB_DISMISSED_COMMENT_MAX_LENGTH = 280;
   const OVERFLOW_TEXT_LENGTH = 3;
   for (const entry of allowList) {
-    if (entry.comment.length <= GITHUB_DISMISSED_COMMENT_MAX_LENGTH)
-      continue;
-    let alertType = entry.cve ? `cve: ${entry.cve}` : `cwe: ${entry.cwe}`;
+    if (entry.comment.length <= GITHUB_DISMISSED_COMMENT_MAX_LENGTH) continue;
+    const alertType = entry.cve ? `cve: ${entry.cve}` : `cwe: ${entry.cwe}`;
     warning(`allowlist comment for ${alertType} is over 280 characters. 
  Truncating comment!`);
     const truncateLength = GITHUB_DISMISSED_COMMENT_MAX_LENGTH - OVERFLOW_TEXT_LENGTH;
-    entry.comment = entry.comment.substring(0, truncateLength) + "...";
+    const truncatedComment = entry.comment.substring(0, truncateLength);
+    entry.comment = `${truncatedComment}...`;
   }
 };
 var validateScannerConfig = (scannerConfig, scanner) => {
@@ -42536,7 +42537,7 @@ var main = async () => {
     const EXTERNAL_REPOSITORY_TOKEN = getInput("external-repository-token");
     const VALID_SCANNERS = ["dockerscan", "codescan"];
     const ThrottledOctokit = Octokit2.plugin(throttling);
-    let octokitExternal = void 0;
+    let octokitExternal;
     if (!VALID_SCANNERS.includes(SCANNER_TYPE)) {
       setFailed(`Invalid scanner defined ${SCANNER_TYPE}`);
       return;

--- a/scanner-action/dist/index.cjs
+++ b/scanner-action/dist/index.cjs
@@ -42427,6 +42427,19 @@ var scannerConfigSchema = (scanner) => {
     required: ["apiVersion", "kind", "metadata", "spec"]
   };
 };
+var validateAllowlist = (allowList) => {
+  const GITHUB_DISMISSED_COMMENT_MAX_LENGTH = 280;
+  const OVERFLOW_TEXT_LENGTH = 3;
+  for (const entry of allowList) {
+    if (entry.comment.length <= GITHUB_DISMISSED_COMMENT_MAX_LENGTH)
+      continue;
+    let alertType = entry.cve ? `cve: ${entry.cve}` : `cwe: ${entry.cwe}`;
+    warning(`allowlist comment for ${alertType} is over 280 characters. 
+ Truncating comment!`);
+    const truncateLength = GITHUB_DISMISSED_COMMENT_MAX_LENGTH - OVERFLOW_TEXT_LENGTH;
+    entry.comment = entry.comment.substring(0, truncateLength) + "...";
+  }
+};
 var validateScannerConfig = (scannerConfig, scanner) => {
   const ajvInstance = new import_ajv.Ajv({
     verbose: true
@@ -42438,6 +42451,7 @@ var validateScannerConfig = (scannerConfig, scanner) => {
     throw Error(`Failed to validate ${scannerConfig.kind}
  ${JSON.stringify(validate.errors, null, 2)}`);
   }
+  if (scannerConfig.spec?.allowlist) validateAllowlist(scannerConfig.spec?.allowlist);
 };
 var getCentralAllowlistConfig = (scannerType, fetchAllowlist = true) => {
   if (!fetchAllowlist) {

--- a/scanner-action/github-issues.ts
+++ b/scanner-action/github-issues.ts
@@ -68,10 +68,10 @@ const removeIssueComment = async (issue: GithubIssue, subtext: string, octokit: 
 				...issue,
 				comment_id: comment.id,
 			});
-		} catch (error) {
+		} catch (_error) {
 			core.warning(`Failed to remove comment ${comment.id} for issue: ${issue.issue_number} with subtext ${subtext}`);
 		}
 	}
 };
 
-export { sendIssueComment, removeIssueComment };
+export { removeIssueComment, sendIssueComment };

--- a/scanner-action/github-security.ts
+++ b/scanner-action/github-security.ts
@@ -81,6 +81,7 @@ const dismissAlerts = async (alerts: PartialCodeScanningAlert[], octokit: Octoki
 			if (allowlistEntry.cwe) {
 				return alert?.rule?.tags?.includes(`external/cwe/${allowlistEntry.cwe}`) && !dismissedAlerts.has(alert.number);
 			}
+			return false;
 		});
 
 		for (const matchingAlert of matchingAlerts) {
@@ -97,4 +98,4 @@ const dismissAlerts = async (alerts: PartialCodeScanningAlert[], octokit: Octoki
 	}
 };
 
-export { getAlerts, dismissAlerts, type SeverityLevel, type PartialCodeScanningAlert };
+export { dismissAlerts, getAlerts, type PartialCodeScanningAlert, type SeverityLevel };

--- a/scanner-action/index.ts
+++ b/scanner-action/index.ts
@@ -15,7 +15,7 @@ const main = async () => {
 
 		const ThrottledOctokit = Octokit.plugin(throttling);
 
-		let octokitExternal: Octokit | undefined = undefined;
+		let octokitExternal: Octokit | undefined;
 
 		if (!VALID_SCANNERS.includes(SCANNER_TYPE)) {
 			core.setFailed(`Invalid scanner defined ${SCANNER_TYPE}`);

--- a/scanner-action/notifications.ts
+++ b/scanner-action/notifications.ts
@@ -2,7 +2,7 @@ import * as core from "@actions/core";
 import * as github from "@actions/github";
 import type { Octokit } from "octokit";
 import { removeIssueComment, sendIssueComment } from "./github-issues.js";
-import { type PartialCodeScanningAlert, type SeverityLevel, getAlerts } from "./github-security.js";
+import { getAlerts, type PartialCodeScanningAlert, type SeverityLevel } from "./github-security.js";
 import { createMarkdown, setNotificationOutputs } from "./outputs.js";
 import type { ScannerConfig } from "./scanner-config.js";
 
@@ -121,4 +121,4 @@ const sendPullRequestNotification = async (scannerNotifications: ScannerNotifica
 	await sendIssueComment(issue, notificationOutput, octokit);
 };
 
-export { ScannerNotifications, runNotifications, type Notifications };
+export { type Notifications, runNotifications, ScannerNotifications };

--- a/scanner-action/outputs.ts
+++ b/scanner-action/outputs.ts
@@ -98,4 +98,4 @@ const setNotificationOutputs = (scannerNotifications: ScannerNotifications) => {
 	core.setOutput("notification_markdown", createMarkdown(scannerNotifications));
 };
 
-export { setNotificationOutputs, createMarkdown };
+export { createMarkdown, setNotificationOutputs };

--- a/scanner-action/scanner-config.ts
+++ b/scanner-action/scanner-config.ts
@@ -224,18 +224,18 @@ const validateAllowlist = (allowList: Allowlist[]) => {
 	const OVERFLOW_TEXT_LENGTH = 3;
 
 	for (const entry of allowList) {
-		if (entry.comment.length <= GITHUB_DISMISSED_COMMENT_MAX_LENGTH)
-			continue;
-		
-		let alertType = entry.cve ? `cve: ${entry.cve}` : `cwe: ${entry.cwe}`;
+		if (entry.comment.length <= GITHUB_DISMISSED_COMMENT_MAX_LENGTH) continue;
+
+		const alertType = entry.cve ? `cve: ${entry.cve}` : `cwe: ${entry.cwe}`;
 
 		// Feedback loop can be long for external allowlist, so warn instead of error
 		core.warning(`allowlist comment for ${alertType} is over 280 characters. \n Truncating comment!`);
-		
+
 		const truncateLength = GITHUB_DISMISSED_COMMENT_MAX_LENGTH - OVERFLOW_TEXT_LENGTH;
-		entry.comment = entry.comment.substring(0, truncateLength) + "...";
+		const truncatedComment = entry.comment.substring(0, truncateLength);
+		entry.comment = `${truncatedComment}...`;
 	}
-}
+};
 
 const validateScannerConfig = (scannerConfig: ScannerConfig, scanner: string) => {
 	const ajvInstance = new Ajv({

--- a/scanner-action/scanner-config.ts
+++ b/scanner-action/scanner-config.ts
@@ -219,6 +219,24 @@ const scannerConfigSchema = (scanner: string) => {
 	};
 };
 
+const validateAllowlist = (allowList: Allowlist[]) => {
+	const GITHUB_DISMISSED_COMMENT_MAX_LENGTH = 280;
+	const OVERFLOW_TEXT_LENGTH = 3;
+
+	for (const entry of allowList) {
+		if (entry.comment.length <= GITHUB_DISMISSED_COMMENT_MAX_LENGTH)
+			continue;
+		
+		let alertType = entry.cve ? `cve: ${entry.cve}` : `cwe: ${entry.cwe}`;
+
+		// Feedback loop can be long for external allowlist, so warn instead of error
+		core.warning(`allowlist comment for ${alertType} is over 280 characters. \n Truncating comment!`);
+		
+		const truncateLength = GITHUB_DISMISSED_COMMENT_MAX_LENGTH - OVERFLOW_TEXT_LENGTH;
+		entry.comment = entry.comment.substring(0, truncateLength) + "...";
+	}
+}
+
 const validateScannerConfig = (scannerConfig: ScannerConfig, scanner: string) => {
 	const ajvInstance = new Ajv({
 		verbose: true,
@@ -232,6 +250,8 @@ const validateScannerConfig = (scannerConfig: ScannerConfig, scanner: string) =>
 	if (!isValid) {
 		throw Error(`Failed to validate ${scannerConfig.kind}\n ${JSON.stringify(validate.errors, null, 2)}`);
 	}
+
+	if (scannerConfig.spec?.allowlist) validateAllowlist(scannerConfig.spec?.allowlist);
 };
 
 const getCentralAllowlistConfig = (scannerType: string, fetchAllowlist = true) => {


### PR DESCRIPTION
## 💡 What does this PR do?
<!--- Provide a concise summary of all the changes included in the pull request -->
Pull request truncates allowlist comment if longer than 280 characters, and will show a warning within job summary. There is a 280 character limit on the field for dismissed_comment when updating alerts. 

Reason for warning instead of error is to help with feedback loop when using a shared allow list config, as the feedback for 280 characters will be first when the pull request for new allow list is merged in shared repository, and other repositories does a code scan / docker scan run. 


<!--- Provide a link to the Github/Jira ticket related to the pull request -->
Closes: [SIK-1970](https://entur.atlassian.net/browse/SIK-1970)

## 🔧 List of changes
<!--- Provide a list of each change included in the pull request -->
* scanner-action
   * add allowlist comment validation
* docs
   * update allowlist documentation to include comments are truncated if longer than 280 characters. 
* ci.yml
  * upgrade biome version to be same as package.json
* biome
  * migrate config to 2.4.16 schema.

## 📋 Checklist
<!--- Follow up on, and tick off the tasks relevant to the pull request. Remove any irrelevant checks -->
- [X] Am familiar with the release pipeline for this project
- [X] I have updated relevant user documentation
- [X] I have verified that the project runs as expected after the new changes

[SIK-1970]: https://entur.atlassian.net/browse/SIK-1970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ