### PR TITLE
feat: add input include_docker_workdir to docker-scan

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -7,6 +7,11 @@ on:
         description: 'Image artifact to scan'
         type: string
         required: true
+      include_docker_workdir:
+        description: 'Include docker workdir for scanning. By default set to false to reduce duplicate vulnerabilities from Dependabot'
+        type: boolean
+        default: false
+        required: false
     secrets:
       external_repository_token:
         description: 'Token to access the external repository mentioned in the dockerscan.yml file. Must have read access to the repository.'
@@ -69,6 +74,7 @@ jobs:
           name: ${{ env.GHA_SECURITY_DOCKER_SCAN_IMAGE_ARTIFACT }}
       - name: "Docker workdir extraction"
         id: docker-workdir
+        if: ${{ !inputs.include_docker_workdir }}
         env:
           IMAGE_ARTIFACT: ${{ inputs.image_artifact }}
         run: |
@@ -83,7 +89,7 @@ jobs:
         id: syft-scan
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         env:
-          SYFT_EXCLUDE: ${{ env.DOCKER_WORKDIR }}
+          SYFT_EXCLUDE: ${{ !inputs.include_docker_workdir && env.DOCKER_WORKDIR  || '' }}
         with:
           format: spdx-json
           image: ${{ inputs.image_artifact }}.tar

--- a/README-docker-scan.md
+++ b/README-docker-scan.md
@@ -25,9 +25,10 @@ Go to the _Actions_ tab in your repository, click on _New workflow_ and select t
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|                                   INPUT                                    |  TYPE  | REQUIRED | DEFAULT |      DESCRIPTION       |
-|----------------------------------------------------------------------------|--------|----------|---------|------------------------|
-| <a name="input_image_artifact"></a>[image_artifact](#input_image_artifact) | string |   true   |         | Image artifact to scan |
+|                                               INPUT                                                |  TYPE   | REQUIRED | DEFAULT |                                                          DESCRIPTION                                                          |
+|----------------------------------------------------------------------------------------------------|---------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------|
+|             <a name="input_image_artifact"></a>[image_artifact](#input_image_artifact)             | string  |   true   |         |                                                    Image artifact to scan                                                     |
+| <a name="input_include_docker_workdir"></a>[include_docker_workdir](#input_include_docker_workdir) | boolean |  false   | `false` | Include docker workdir for scanning. <br>By default set to false <br>to reduce duplicate vulnerabilities from <br>Dependabot  |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/README-docker-scan.md
+++ b/README-docker-scan.md
@@ -161,6 +161,27 @@ The format and location of the config can be found [in the section below](#docke
 ### Known issues
 * Notifications fetches alerts before allowlist changes happen for Docker Scan.
 
+## Docker image working directory
+By default, Docker Scan excludes the Docker image's working directory, which is
+where application code is usually copied to.
+
+We exclude this because the goal of Docker Scan is to find vulnerabilities in the base image,  
+not the application. Code Scanning and Dependabot are used to find vulnerabilities in application code.
+
+There are edge cases where the application code is shipped inside the Docker image itself.  
+To scan these images fully, you can configure Docker Scan to include the working directory:
+
+```yaml
+jobs:
+  docker-scan:
+    needs: ...
+    uses: entur/gha-security/.github/workflows/docker-scan.yml@v2
+    secrets: inherit
+    with:
+        image_artifact: ...
+        include_docker_workdir: true
+```
+
 ## Docker Scan config
 
 Requirements for Docker Scan config:

--- a/README-docker-scan.md
+++ b/README-docker-scan.md
@@ -158,9 +158,6 @@ Pull request notifications (comments) are enabled by default, but can be disable
 
 The format and location of the config can be found [in the section below](#docker-scan-config).
 
-### Known issues
-* Notifications fetches alerts before allowlist changes happen for Docker Scan.
-
 ## Docker image working directory
 By default, Docker Scan excludes the Docker image's working directory, which is
 where application code is usually copied to.


### PR DESCRIPTION
## 💡 What does this PR do?
<!--- Provide a concise summary of all the changes included in the pull request -->
This pull request aims to provide a way to include docker working directory for scanning.
By default Docker Scan excludes the working directory in a Docker image.

This is to handle edge cases where application code is inside the docker image itself than copied from repositories.


<!--- Provide a link to the Github/Jira ticket related to the pull request -->
Closes: [SIK-2015](https://entur.atlassian.net/browse/SIK-2015)

## 🔧 List of changes
<!--- Provide a list of each change included in the pull request -->
* docker-scan
  * add input `include_docker_workdir` 
* docs
  * add section regarding docker scan working directory
  * remove old known issues section which is resolved

## 📋 Checklist
<!--- Follow up on, and tick off the tasks relevant to the pull request. Remove any irrelevant checks -->
- [X] Am familiar with the release pipeline for this project
- [x] I have updated relevant user documentation
- [X] I have verified that the project runs as expected after the new changes

[SIK-2015]: https://entur.atlassian.net/browse/SIK-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ