### PR TITLE
feat: add codeql kotlin support warning

### DIFF
--- a/.github/actions/codeql-kotlin-error-handler/action.yml
+++ b/.github/actions/codeql-kotlin-error-handler/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         ACTION_PATH: ${{ github.action_path }}
-        JOB_VALUE: ${{ inputs.find_value }}
+        RUNNER_OS: ${{ runner.os }}
       with:
         script: |
           const errorHandler = require(`${process.env.ACTION_PATH}/index.js`);

--- a/.github/actions/codeql-kotlin-error-handler/action.yml
+++ b/.github/actions/codeql-kotlin-error-handler/action.yml
@@ -1,0 +1,33 @@
+name: 'CodeQL Kotlin Error Handler'
+description: 'Handle error from CodeQL auto-build that fails when Kotlin version is not supported'
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Handle CodeQL Kotlin error"
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        JOB_VALUE: ${{ inputs.find_value }}
+      with:
+        script: |
+          const errorHandler = require(`${process.env.ACTION_PATH}/index.js`);
+          
+          try {
+            await errorHandler({ core, glob });
+          } catch(error) {
+            core.setFailed(error.message)
+          }
+          
+
+
+          
+          
+          
+        
+        
+
+
+
+
+# 

--- a/.github/actions/codeql-kotlin-error-handler/action.yml
+++ b/.github/actions/codeql-kotlin-error-handler/action.yml
@@ -18,16 +18,3 @@ runs:
           } catch(error) {
             core.setFailed(error.message)
           }
-          
-
-
-          
-          
-          
-        
-        
-
-
-
-
-# 

--- a/.github/actions/codeql-kotlin-error-handler/index.js
+++ b/.github/actions/codeql-kotlin-error-handler/index.js
@@ -1,0 +1,48 @@
+const getActionRunnerLog = async (fs, glob) => {
+    try {
+
+        const globber = await glob.create("~/actions-runner/cached/*/_diag/blocks/*", {
+            followSymbolicLinks: false
+        });
+
+        const files = await globber.glob();
+
+        return files.map(file => fs.readFileSync(file, 'utf8')).join("\n");
+
+    } catch (error) {
+        throw new Error("Failed to get action runner log", { cause: error })
+    }
+}
+
+module.exports = async ({ core, glob }) => {
+    const fs = require('fs');
+    
+    const actionRunnerLog = await getActionRunnerLog(fs, glob);
+    const supportErrorMessage = actionRunnerLog
+        .split("\n")
+        .find(line =>
+            /Kotlin version (\d+\.\d+\.\d+) is too recent. CodeQL currently supports versions below (\d+\.\d+\.\d+)/.test(line));
+
+    // if no message found related to CodeQL kotlin support, silently quit
+    if (!supportErrorMessage)
+        return;
+
+    const matches = supportErrorMessage.match(/Kotlin version (\d+\.\d+\.\d+) is too recent. CodeQL currently supports versions below (\d+\.\d+\.\d+)/)
+
+    const [_, kotlinVersion, incompatibleKotlinVersion] = matches;
+     
+
+    await core.summary
+        .addHeading(`CodeQL analysis failed with too recent Kotlin version`)
+        .addRaw(`Kotlin ${kotlinVersion} version too recent for CodeQL, CodeQL supports versions below ${incompatibleKotlinVersion}.`)
+        .addBreak()
+        .addRaw("To continue using Code Scan, please wait with Kotlin upgrade until it's supported by CodeQL.")
+        .addBreak()
+        .addBreak()
+        .addRaw('See <a href="https://Github.com/Github/codeql/issues?q=is%3Aissue%20Support%20Kotlin">Github issues</a> for status on CodeQL Kotlin Support')
+        .addSeparator()
+        .write()
+
+
+    core.setFailed(`Kotlin ${kotlinVersion} version too recent for CodeQL, CodeQL supports versions below ${incompatibleKotlinVersion}`)
+}

--- a/.github/actions/codeql-kotlin-error-handler/index.js
+++ b/.github/actions/codeql-kotlin-error-handler/index.js
@@ -29,16 +29,16 @@ module.exports = async ({ core, glob }) => {
     const supportErrorMessage = actionRunnerLog
         .split("\n")
         .find(line =>
-            /Kotlin version (\d+\.\d+\.\d+) is too recent. CodeQL currently supports versions below (\d+\.\d+\.\d+)/.test(line));
+            /Kotlin version (.*) is too recent. CodeQL currently supports versions below (.*)/.test(line));
 
     // if no message found related to CodeQL kotlin support, silently quit
     if (!supportErrorMessage)
         return;
 
-    const matches = supportErrorMessage.match(/Kotlin version (\d+\.\d+\.\d+) is too recent. CodeQL currently supports versions below (\d+\.\d+\.\d+)/)
+    const matches = supportErrorMessage.match(/Kotlin version (.*) is too recent. CodeQL currently supports versions below (.*)/)
 
     const [_, kotlinVersion, incompatibleKotlinVersion] = matches;
-     
+
 
     await core.summary
         .addHeading(`CodeQL analysis failed with too recent Kotlin version`)

--- a/.github/actions/codeql-kotlin-error-handler/index.js
+++ b/.github/actions/codeql-kotlin-error-handler/index.js
@@ -1,6 +1,10 @@
+// Github doesn't have a way to get previous log lines of a job.
+// So we take advantage of the logs being stored in the actions-runner, so we can look for the error line from CodeQL autobuild.
+// NOTE: if Github one day, allows you to read logs using Official API, then use that instead.
 const getActionRunnerLog = async (fs, glob) => {
     try {
-
+        // Globber is used here to fetch the files, there is usually 2 files generated here.
+        // One for the log of current step, and one for the entire job.
         const globber = await glob.create("~/actions-runner/cached/*/_diag/blocks/*", {
             followSymbolicLinks: false
         });
@@ -15,6 +19,10 @@ const getActionRunnerLog = async (fs, glob) => {
 }
 
 module.exports = async ({ core, glob }) => {
+    // This action does not support macOS/Windows
+    if (process.env.RUNNER_OS != "Linux")
+        return;
+
     const fs = require('fs');
     
     const actionRunnerLog = await getActionRunnerLog(fs, glob);

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -447,7 +447,7 @@ jobs:
 
       - name: "CodeQL Kotlin Error Handler"
         if: failure() && steps.codeql-analysis.outcome == 'failure' && matrix.language == 'kotlin'
-        uses: entur/gha-security/.github/codeql-kotlin-error-handler@v2
+        uses: entur/gha-security/.github/actions/codeql-kotlin-error-handler@v2
 
       - name: "Post message to job summary if scan with HTML only files fail"
         if: ${{ failure() && steps.codeql-analysis.outcome == 'failure' && needs.get-repository-metadata.outputs.html_only_scan == 'True' && matrix.language == 'javascript-typescript' }}

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -447,7 +447,7 @@ jobs:
 
       - name: "CodeQL Kotlin Error Handler"
         if: failure() && steps.codeql-analysis.outcome == 'failure' && matrix.language == 'kotlin'
-        uses: ./.github/actions/codeql-kotlin-error-handler
+        uses: entur/gha-security/.github/codeql-kotlin-error-handler@v2
 
       - name: "Post message to job summary if scan with HTML only files fail"
         if: ${{ failure() && steps.codeql-analysis.outcome == 'failure' && needs.get-repository-metadata.outputs.html_only_scan == 'True' && matrix.language == 'javascript-typescript' }}

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -445,6 +445,10 @@ jobs:
           mode: clear
           export-secrets: ${{ inputs.additional_build_secrets }}
 
+      - name: "CodeQL Kotlin Error Handler"
+        if: failure() && steps.codeql-analysis.outcome == 'failure' && matrix.language == 'kotlin'
+        uses: ./.github/actions/codeql-kotlin-error-handler
+
       - name: "Post message to job summary if scan with HTML only files fail"
         if: ${{ failure() && steps.codeql-analysis.outcome == 'failure' && needs.get-repository-metadata.outputs.html_only_scan == 'True' && matrix.language == 'javascript-typescript' }}
         run: |

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -106,7 +106,7 @@ jobs:
                   should-fail: true
                 - title: "Should silently exit if no Kotlin support error"
                   log-message: "No errors found here!"
-                  should-fail: no
+                  should-fail: false
                 - title: "temp-test-assert"
                   log-message: "No errors found here!"
                   should-fail: true

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -95,8 +95,31 @@ jobs:
               script: |
                 const assertSarifFix = require("./.github/test-scripts/assert-sarif-fix.js");
                 assertSarifFix({ core });
-
-
+    test-codeql-kotlin-error-handler:
+      runs-on: ubuntu-24.04
+      name: ${{ matrix.test.title }}
+      strategy:
+          matrix:
+              test:
+                - title: "Should fail with Kotlin support error"
+                  log-message: "Kotlin version 2.4.0 is too recent. CodeQL currently supports versions below 2.3.30\n ..."
+                  should-fail: true
+                - title: "Should silently exit if no Kotlin support error"
+                  log-message: "No errors found here!"
+                  should-fail: no
+      steps:
+        - name: "Checkout repository"
+          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2
+          with:
+            persist-credentials: false
+        - name: "Log message"
+          env:
+            LOG_MESSAGE: ${{ matrix.test.log-message }}
+          run: |
+            echo "$LOG_MESSAGE"
+        - name: "CodeQL Kotlin error handler"
+          continue-on-error: ${{ fromJSON(matrix.test.should-fail) }}
+          uses: ./.github/actions/codeql-kotlin-error-handler
     test-dynamic-secrets:
       runs-on: ubuntu-24.04
       name: ${{ matrix.test.title }}

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -107,6 +107,9 @@ jobs:
                 - title: "Should silently exit if no Kotlin support error"
                   log-message: "No errors found here!"
                   should-fail: no
+                - title: "temp-test-assert"
+                  log-message: "No errors found here!"
+                  should-fail: true
       steps:
         - name: "Checkout repository"
           uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2
@@ -118,8 +121,19 @@ jobs:
           run: |
             echo "$LOG_MESSAGE"
         - name: "CodeQL Kotlin error handler"
+          id: codeql-kotlin-error-handler
           continue-on-error: ${{ fromJSON(matrix.test.should-fail) }}
           uses: ./.github/actions/codeql-kotlin-error-handler
+        - name: "Assert step outcome"
+          if: ${{ fromJson(matrix.test.should-fail) && steps.codeql-kotlin-error-handler.outcome != 'failure' }}
+          env:
+            EXPECTED_OUTCOME: ${{ fromJson(matrix.test.should-fail) && 'failure' || 'success'  }}
+            STEP_OUTCOME: ${{ steps.codeql-kotlin-error-handler.outcome }}
+          run: |
+            echo "::error::Assert failed: expected step outcome to be $EXPECTED_OUTCOME but actual outcome is $STEP_OUTCOME"
+            exit 1;
+            
+            
     test-dynamic-secrets:
       runs-on: ubuntu-24.04
       name: ${{ matrix.test.title }}

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -119,12 +119,12 @@ jobs:
             echo "$LOG_MESSAGE"
         - name: "CodeQL Kotlin error handler"
           id: codeql-kotlin-error-handler
-          continue-on-error: ${{ fromJSON(matrix.test.should-fail) }}
+          continue-on-error: ${{ matrix.test.should-fail }}
           uses: ./.github/actions/codeql-kotlin-error-handler
         - name: "Assert step outcome"
-          if: ${{ fromJson(matrix.test.should-fail) && steps.codeql-kotlin-error-handler.outcome != 'failure' }}
+          if: ${{ matrix.test.should-fail && steps.codeql-kotlin-error-handler.outcome != 'failure' }}
           env:
-            EXPECTED_OUTCOME: ${{ fromJson(matrix.test.should-fail) && 'failure' || 'success'  }}
+            EXPECTED_OUTCOME: ${{ matrix.test.should-fail && 'failure' || 'success'  }}
             STEP_OUTCOME: ${{ steps.codeql-kotlin-error-handler.outcome }}
           run: |
             echo "::error::Assert failed: expected step outcome to be $EXPECTED_OUTCOME but actual outcome is $STEP_OUTCOME"

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -107,6 +107,8 @@ jobs:
                 - title: "Should silently exit if no Kotlin support error"
                   log-message: "No errors found here!"
                   should-fail: false
+                - title: "Should fail with Kotlin support error when using Beta version"
+                  log-message: "Kotlin version 2.4.20-Beta1 is too recent. CodeQL currently supports versions below 2.3.30\n ..."
       steps:
         - name: "Checkout repository"
           uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -107,9 +107,6 @@ jobs:
                 - title: "Should silently exit if no Kotlin support error"
                   log-message: "No errors found here!"
                   should-fail: false
-                - title: "temp-test-assert"
-                  log-message: "No errors found here!"
-                  should-fail: true
       steps:
         - name: "Checkout repository"
           uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -109,6 +109,7 @@ jobs:
                   should-fail: false
                 - title: "Should fail with Kotlin support error when using Beta version"
                   log-message: "Kotlin version 2.4.20-Beta1 is too recent. CodeQL currently supports versions below 2.3.30\n ..."
+                  should-fail: true
       steps:
         - name: "Checkout repository"
           uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2


### PR DESCRIPTION
## 💡 What does this PR do?
<!--- Provide a concise summary of all the changes included in the pull request -->
CodeQL support for Kotlin is dependent on Kotlin version. So it will fail if CodeQL does not support the Kotlin version running. Sadly this error happens in the Gradle log, and is not always clear for developers when it happens.

So this pull request reads actions-runner logs, uses regex to check if error exists, and extracts out the version the kotlin version found, and incompatible kotlin version.

<!--- Provide a link to the Github/Jira ticket related to the pull request -->
Closes: [SIK-1965](https://entur.atlassian.net/browse/SIK-1965)

## 🔧 List of changes
<!--- Provide a list of each change included in the pull request -->
* Add new action codeql-kotlin-error-handler
* Add tests for action codeql-kotlin-error-handler
* Integrate codeql-kotlin-error-handler into Code Scan

## 📋 Checklist
<!--- Follow up on, and tick off the tasks relevant to the pull request. Remove any irrelevant checks -->
- [x] Am familiar with the release pipeline for this project
- [x] I have added relevant tests for the new changes
- [x] I have verified that the project runs as expected after the new changes

[SIK-1965]: https://entur.atlassian.net/browse/SIK-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ