### PR TITLE
Use toolchains.xml from setup-java instead of setup-gradle

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -276,7 +276,10 @@ jobs:
           server-id: ${{ inputs.java_server_id_artifactory }}
           use_maven_cache: ${{ inputs.use_maven_cache }}
           
-      - name: Back up Setup Java toolchains.xml
+      # setup-gradle overwrites toolchains.xml from setup-java, preserve it so we get the requested version and 
+      # distribution instead of the autodetected version from gradle build files.
+      # See also https://github.com/github/codeql-action/issues/2752
+      - name: Backup Setup-Java toolchains.xml
         if: needs.get-repository-metadata.outputs.found_gradle == 'True' && (matrix.language == 'kotlin' || matrix.language == 'java')
         run: cp ~/.m2/toolchains.xml ~/.m2/toolchains.xml.bak
 
@@ -289,7 +292,7 @@ jobs:
           dependency-graph: 'generate-and-upload'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           
-      - name: Back up Setup Java toolchains.xml
+      - name: Restore Setup-Java toolchains.xml
         if: needs.get-repository-metadata.outputs.found_gradle == 'True' && (matrix.language == 'kotlin' || matrix.language == 'java')
         run: mv ~/.m2/toolchains.xml.bak ~/.m2/toolchains.xml
   

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -280,7 +280,7 @@ jobs:
       # distribution instead of the autodetected version from gradle build files.
       # See also https://github.com/github/codeql-action/issues/2752
       - name: Backup Setup-Java toolchains.xml
-        if: needs.get-repository-metadata.outputs.found_gradle == 'True' && (matrix.language == 'kotlin' || matrix.language == 'java')
+        if: inputs.use_setup_java && needs.get-repository-metadata.outputs.found_gradle == 'True' && (matrix.language == 'kotlin' || matrix.language == 'java')
         run: cp ~/.m2/toolchains.xml ~/.m2/toolchains.xml.bak
 
       - name: "Set up Gradle for Java/Kotlin"
@@ -293,7 +293,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Restore Setup-Java toolchains.xml
-        if: needs.get-repository-metadata.outputs.found_gradle == 'True' && (matrix.language == 'kotlin' || matrix.language == 'java')
+        if: inputs.use_setup_java && needs.get-repository-metadata.outputs.found_gradle == 'True' && (matrix.language == 'kotlin' || matrix.language == 'java')
         run: mv ~/.m2/toolchains.xml.bak ~/.m2/toolchains.xml
   
       - name: "Initialize CodeQL for Java/Kotlin"

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -275,6 +275,9 @@ jobs:
           distribution: ${{ inputs.java_distribution }}
           server-id: ${{ inputs.java_server_id_artifactory }}
           use_maven_cache: ${{ inputs.use_maven_cache }}
+          
+      - name: Back up Setup Java toolchains.xml
+        run: cp ~/.m2/toolchains.xml ~/.m2/toolchains.xml.bak
 
       - name: "Set up Gradle for Java/Kotlin"
         if: needs.get-repository-metadata.outputs.found_gradle == 'True' && (matrix.language == 'kotlin' || matrix.language == 'java')
@@ -284,7 +287,10 @@ jobs:
           add-job-summary: 'on-failure'
           dependency-graph: 'generate-and-upload'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
+          
+      - name: Back up Setup Java toolchains.xml
+        run: mv ~/.m2/toolchains.xml.bak ~/.m2/toolchains.xml
+  
       - name: "Initialize CodeQL for Java/Kotlin"
         if: matrix.language == 'kotlin' || matrix.language == 'java'
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -277,6 +277,7 @@ jobs:
           use_maven_cache: ${{ inputs.use_maven_cache }}
           
       - name: Back up Setup Java toolchains.xml
+        if: needs.get-repository-metadata.outputs.found_gradle == 'True' && (matrix.language == 'kotlin' || matrix.language == 'java')
         run: cp ~/.m2/toolchains.xml ~/.m2/toolchains.xml.bak
 
       - name: "Set up Gradle for Java/Kotlin"
@@ -289,6 +290,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Back up Setup Java toolchains.xml
+        if: needs.get-repository-metadata.outputs.found_gradle == 'True' && (matrix.language == 'kotlin' || matrix.language == 'java')
         run: mv ~/.m2/toolchains.xml.bak ~/.m2/toolchains.xml
   
       - name: "Initialize CodeQL for Java/Kotlin"


### PR DESCRIPTION
## 💡 What does this PR do?
Fix [job failure](https://github.com/entur/abt-cuckoo-filter/actions/runs/29321621032/job/87048087728?pr=38) when output source compatibility version is lower than minimum tooling version.

Makes sure the JVM version and JVM distribution specified in the workflow input is used (as set by setup-java action). 

## 🔧 List of changes
* Creates a backup of toolchains.xml before running setup-gradle. Then restores the file after. Only runs if setup-java and setup-gradle runs.

## 📋 Checklist
- [ ] Am familiar with the release pipeline for this project
- [ ] I have updated relevant developer documentation
- [ ] I have updated relevant user documentation
- [ ] I have added relevant tests for the new changes
- [x] I have verified that the project runs as expected after the new changes: https://github.com/entur/abt-cuckoo-filter/actions/runs/29403438003