### PR TITLE
fix: Remove docker scan comment if there are no longer errors

### DIFF
--- a/scanner-action/dist/index.cjs
+++ b/scanner-action/dist/index.cjs
@@ -42412,12 +42412,14 @@ var runNotifications = async (octokitAction, scannerType, scannerConfig) => {
 };
 var sendPullRequestNotification = async (scannerNotifications, octokit) => {
   const isPullRequestEnabled = scannerNotifications.config.outputs?.pullRequest?.enabled ?? true;
-  const skipNotification = !isPullRequestEnabled || context2.eventName !== "pull_request" || !scannerNotifications.alertsFound;
+  const skipNotification = !isPullRequestEnabled || context2.eventName !== "pull_request";
   if (skipNotification) return;
   const notificationOutput = createMarkdown(scannerNotifications);
   const issue2 = { issue_number: context2.issue.number, owner: context2.issue.owner, repo: context2.issue.repo };
   await removeIssueComment(issue2, `<!-- gha-security:${scannerNotifications.scannerType} -->`, octokit);
-  await sendIssueComment(issue2, notificationOutput, octokit);
+  if (scannerNotifications.alertsFound) {
+    await sendIssueComment(issue2, notificationOutput, octokit);
+  }
 };
 
 // scanner-config.ts

--- a/scanner-action/notifications.ts
+++ b/scanner-action/notifications.ts
@@ -109,7 +109,7 @@ const runNotifications = async (octokitAction: Octokit, scannerType: string, sca
 const sendPullRequestNotification = async (scannerNotifications: ScannerNotifications, octokit: Octokit) => {
 	const isPullRequestEnabled = scannerNotifications.config.outputs?.pullRequest?.enabled ?? true;
 
-	const skipNotification = !isPullRequestEnabled || github.context.eventName !== "pull_request" || !scannerNotifications.alertsFound;
+	const skipNotification = !isPullRequestEnabled || github.context.eventName !== "pull_request";
 
 	if (skipNotification) return;
 
@@ -118,7 +118,9 @@ const sendPullRequestNotification = async (scannerNotifications: ScannerNotifica
 	const issue = { issue_number: github.context.issue.number, owner: github.context.issue.owner, repo: github.context.issue.repo };
 
 	await removeIssueComment(issue, `<!-- gha-security:${scannerNotifications.scannerType} -->`, octokit);
-	await sendIssueComment(issue, notificationOutput, octokit);
+	if (scannerNotifications.alertsFound) {
+		await sendIssueComment(issue, notificationOutput, octokit);
+	}
 };
 
 export { type Notifications, runNotifications, ScannerNotifications };


### PR DESCRIPTION
## 💡 What does this PR do?
Previously, the code exited before removing comment if there were no alerts above the threshold. This meant that if a PR had vulnerabilities, but the vulns were fixed in another PR and the PR rebased, the comment would not be removed, despite there not being any vulns anymore. This change fixes that by always removing the comment, before re-inserting it if there are vulns.

Discovered in: https://github.com/entur/api-spec-registry/pull/169. This PR previously had 1 high vulnerability, https://github.com/entur/api-spec-registry/security/code-scanning/172, but this was fixed by merging https://github.com/entur/api-spec-registry/pull/167. Despite this, the comment remained after rebasing the PR.

## 🔧 List of changes
* Call `removeIssueComment`also when `scannerNotifications.alertsFound` is `false`

## 📋 Checklist
<!--- Follow up on, and tick off the tasks relevant to the pull request. Remove any irrelevant checks -->
- [ ] Am familiar with the release pipeline for this project
- [ ] I have updated relevant developer documentation
- [ ] I have updated relevant user documentation
- [ ] I have added relevant tests for the new changes
- [ ] I have verified that the project runs as expected after the new changes