### PR TITLE
Fix Slack notification in docker-scan and code-scan

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -367,12 +367,17 @@ jobs:
       contents: read
       issues: write # required for creating issues, and/or adding issue comments
       pull-requests: write # required for creating comments on pull requests
+    outputs:
+      notification_slack_enabled: ${{ steps.scanner-action.outputs.notification_slack_enabled }}
+      notification_severity_alert_found: ${{ steps.scanner-action.outputs.notification_severity_alert_found }}
+      notification_slack_channel_id: ${{ steps.scanner-action.outputs.notification_slack_channel_id }}
+      notification_slack_block: ${{ steps.scanner-action.outputs.notification_slack_block }}
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2
         with:
           persist-credentials: false
-      
+
       - name: Scanner Action
         id: scanner-action
         uses: entur/gha-security/scanner-action@v2
@@ -387,17 +392,15 @@ jobs:
           NOTIFICATION_MARKDOWN: ${{ steps.scanner-action.outputs.notification_markdown }}
         run: |
           echo "$NOTIFICATION_MARKDOWN" >> "$GITHUB_STEP_SUMMARY"
-      # Taken from https://github.com/entur/gha-slack/blob/main/.github/workflows/post.yml
-      - name: "Send slack notification"
-        if: ${{ steps.scanner-action.outputs.notification_slack_enabled == 'True' && steps.scanner-action.outputs.notification_severity_alert_found == 'True' }}
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          NOTIFICATION_SLACK_POST_BLOCKS: ${{ steps.scanner-action.outputs.notification_slack_block }}
-        with:
-          channel-id: ${{ steps.scanner-action.outputs.notification_slack_channel_id }}
-          payload: |
-            ${{ env.NOTIFICATION_SLACK_POST_BLOCKS }}
+
+  send-slack-notification:
+    needs: scanner-action
+    if: ${{ needs.scanner-action.outputs.notification_slack_enabled == 'True' && needs.scanner-action.outputs.notification_severity_alert_found == 'True' }}
+    uses: entur/gha-slack/.github/workflows/post.yml@v3
+    with:
+      channel_id: ${{ needs.scanner-action.outputs.notification_slack_channel_id }}
+      blocks: ${{ toJSON(fromJSON(needs.scanner-action.outputs.notification_slack_block).blocks) }}
+    secrets: inherit
 
   # fallback if no dependency-graph artifactory exists from a pull request, and CodeQL/Semgrep analysis was running under default branch
   upload-dependency-graph:

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -399,7 +399,7 @@ jobs:
     uses: entur/gha-slack/.github/workflows/post.yml@v3
     with:
       channel_id: ${{ needs.scanner-action.outputs.notification_slack_channel_id }}
-      blocks: ${{ toJSON(fromJSON(needs.scanner-action.outputs.notification_slack_block).blocks) }}
+      blocks: ${{ needs.scanner-action.outputs.notification_slack_block }}
     secrets: inherit
 
   # fallback if no dependency-graph artifactory exists from a pull request, and CodeQL/Semgrep analysis was running under default branch

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -39,8 +39,13 @@ jobs:
       contents: write # required for checking out the repository and creating files
       issues: write # required for creating issues, and/or adding issue comments
       pull-requests: write # required for creating comments on pull requests
-      security-events: write # required for uploading SARIF file to GitHub 
+      security-events: write # required for uploading SARIF file to GitHub
       actions: read #required for uploading SARIF file to GitHub (workflows in private repositories)
+    outputs:
+      notification_slack_enabled: ${{ steps.scanner-action.outputs.notification_slack_enabled }}
+      notification_severity_alert_found: ${{ steps.scanner-action.outputs.notification_severity_alert_found }}
+      notification_slack_channel_id: ${{ steps.scanner-action.outputs.notification_slack_channel_id }}
+      notification_slack_block: ${{ steps.scanner-action.outputs.notification_slack_block }}
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2
@@ -135,14 +140,11 @@ jobs:
         run: |
           echo "$NOTIFICATION_MARKDOWN" >> "$GITHUB_STEP_SUMMARY"
 
-      # Taken from https://github.com/entur/gha-slack/blob/main/.github/workflows/post.yml
-      - name: "Send slack notification"
-        if: ${{ steps.scanner-action.outputs.notification_slack_enabled == 'True' && steps.scanner-action.outputs.notification_severity_alert_found == 'True' }}
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3.27.3.0.3
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          NOTIFICATION_SLACK_POST_BLOCKS: ${{ steps.scanner-action.outputs.notification_slack_block }}
-        with:
-          channel-id: ${{ steps.scanner-action.outputs.notification_slack_channel_id }}
-          payload: |
-            ${{ env.NOTIFICATION_SLACK_POST_BLOCKS }}
+  send-slack-notification:
+    needs: docker-scan
+    if: ${{ needs.docker-scan.outputs.notification_slack_enabled == 'True' && needs.docker-scan.outputs.notification_severity_alert_found == 'True' }}
+    uses: entur/gha-slack/.github/workflows/post.yml@v3
+    with:
+      channel_id: ${{ needs.docker-scan.outputs.notification_slack_channel_id }}
+      blocks: ${{ toJSON(fromJSON(needs.docker-scan.outputs.notification_slack_block).blocks) }}
+    secrets: inherit

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -146,5 +146,5 @@ jobs:
     uses: entur/gha-slack/.github/workflows/post.yml@v3
     with:
       channel_id: ${{ needs.docker-scan.outputs.notification_slack_channel_id }}
-      blocks: ${{ toJSON(fromJSON(needs.docker-scan.outputs.notification_slack_block).blocks) }}
+      blocks: ${{ needs.docker-scan.outputs.notification_slack_block }}
     secrets: inherit

--- a/scanner-action/dist/index.cjs
+++ b/scanner-action/dist/index.cjs
@@ -42306,35 +42306,34 @@ var getScannerReport = (scannerNotifications) => {
 var createSlackBlock = (scannerNotifications) => {
   const scannerReport = getScannerReport(scannerNotifications);
   const githubRepository = getGithubRepository();
-  return {
-    blocks: [
-      {
-        type: "header",
-        text: {
-          type: "plain_text",
-          text: `${scannerReport.header} on ${githubRepository}`
-        }
-      },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `*Results*
+  const blocks = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: `${scannerReport.header} on ${githubRepository}`
+      }
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Results*
 ${scannerReport.resultsList}  
 ${scannerReport.scannerTypeName} Report can be found <${scannerReport.resultsUrl}|here>`
-        }
-      },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `*Allowlist*
+      }
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Allowlist*
 Use the allowlist if you want to ignore vulnerabilities that do not affect the repository. 
 See the <${scannerReport.allowListDocumentationUrl}|${scannerReport.scannerTypeName} documentation> on how to use allowlist.`
-        }
       }
-    ]
-  };
+    }
+  ];
+  return JSON.stringify(blocks, null, " ");
 };
 var setNotificationOutputs = (scannerNotifications) => {
   setOutput("notification_severity_alert_found", outputBool(scannerNotifications.alertsFound));

--- a/scanner-action/outputs.ts
+++ b/scanner-action/outputs.ts
@@ -56,35 +56,35 @@ const createSlackBlock = (scannerNotifications: ScannerNotifications) => {
 	const scannerReport = getScannerReport(scannerNotifications);
 	const githubRepository = getGithubRepository();
 
-	return {
-		blocks: [
-			{
-				type: "header",
-				text: {
-					type: "plain_text",
-					text: `${scannerReport.header} on ${githubRepository}`,
-				},
+	const blocks = [
+		{
+			type: "header",
+			text: {
+				type: "plain_text",
+				text: `${scannerReport.header} on ${githubRepository}`,
 			},
-			{
-				type: "section",
-				text: {
-					type: "mrkdwn",
-					text: `*Results*
+		},
+		{
+			type: "section",
+			text: {
+				type: "mrkdwn",
+				text: `*Results*
 ${scannerReport.resultsList}  
 ${scannerReport.scannerTypeName} Report can be found <${scannerReport.resultsUrl}|here>`,
-				},
 			},
-			{
-				type: "section",
-				text: {
-					type: "mrkdwn",
-					text: `*Allowlist*
+		},
+		{
+			type: "section",
+			text: {
+				type: "mrkdwn",
+				text: `*Allowlist*
 Use the allowlist if you want to ignore vulnerabilities that do not affect the repository. 
 See the <${scannerReport.allowListDocumentationUrl}|${scannerReport.scannerTypeName} documentation> on how to use allowlist.`,
-				},
 			},
-		],
-	};
+		},
+	];
+
+	return JSON.stringify(blocks, null, " ");
 };
 
 const setNotificationOutputs = (scannerNotifications: ScannerNotifications) => {


### PR DESCRIPTION
## 💡 What does this PR do?
  Fixes the Slack notification step in `docker-scan.yml` and `code-scan.yml`, which always failed (`Missing input! Either a method or webhook is required to take action.`) because it used old v1-style `channel-id`/`payload` inputs against a `slack-github-action` version (v3.0.3) that no longer supports them.

  ## 🔧 List of changes
  * _Replaced the direct `slackapi/slack-github-action` call with a new `send-slack-notification` job that uses `entur/gha-slack`'s `post.yml` reusable workflow.
  * Exposed the scanner's notification outputs as job outputs so the new job can consume them.