### PR TITLE
chore: fix flaky CI/CD actions test

### DIFF
--- a/.github/actions/codeql-kotlin-error-handler/index.js
+++ b/.github/actions/codeql-kotlin-error-handler/index.js
@@ -5,7 +5,7 @@ const getActionRunnerLog = async (fs, glob) => {
     try {
         // Globber is used here to fetch the files, there is usually 2 files generated here.
         // One for the log of current step, and one for the entire job.
-        const globber = await glob.create("~/actions-runner/cached/*/_diag/blocks/*", {
+        const globber = await glob.create("~/**/**/_diag/blocks/*", {
             followSymbolicLinks: false
         });
 

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -120,6 +120,8 @@ jobs:
             LOG_MESSAGE: ${{ matrix.test.log-message }}
           run: |
             echo "$LOG_MESSAGE"
+            for i in $(seq 1 100); do echo "padding-line-$i"; done
+            echo "::endgroup::"
         - name: "CodeQL Kotlin error handler"
           id: codeql-kotlin-error-handler
           continue-on-error: ${{ matrix.test.should-fail }}


### PR DESCRIPTION
## 💡 What does this PR do?
<!--- Provide a concise summary of all the changes included in the pull request -->
This pull request fixes a flaky CI/CD github actions test. Added 100 lines being logged to make sure output is flushed to the files, and there are a chance of action logs being on /extracted directory instead of cached.

## 🔧 List of changes
<!--- Provide a list of each change included in the pull request -->
* Update glob path for `codeql-kotlin-error-handler`
* Update test actions to write 100 lines after kotlin error message to flush output

## 📋 Checklist
<!--- Follow up on, and tick off the tasks relevant to the pull request. Remove any irrelevant checks -->
- [X] Am familiar with the release pipeline for this project
- [x] I have verified that the project runs as expected after the new changes